### PR TITLE
refactor: add lifespan client and pydantic models

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,24 +1,42 @@
 #!/usr/bin/env python3
 import os, time, json, uuid
-from typing import Optional, Dict, Any, List
+from typing import Optional, Dict, Any, List, Literal, Union, Tuple
 from collections import defaultdict, deque
 
 import httpx
-from fastapi import FastAPI, Request, Header, HTTPException
+from fastapi import FastAPI, Request, Header, HTTPException, Depends
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, StreamingResponse
+from pydantic import BaseModel
+from pydantic_settings import BaseSettings
 
-# ===== Konfigurace z ENV =====
-OLLAMA_URL = os.getenv("OLLAMA_URL", "http://127.0.0.1:11434")
-API_KEYS = {k.strip() for k in os.getenv("API_KEYS", "").split(",") if k.strip()}
-ALLOWED_ORIGINS = [o.strip() for o in os.getenv("ALLOWED_ORIGINS", "*").split(",") if o.strip()]
-RATE_LIMIT_PER_MIN = int(os.getenv("RATE_LIMIT_PER_MIN", "120"))
+# ===== Konfigurace =====
+class Settings(BaseSettings):
+    ollama_url: str = "http://127.0.0.1:11434"
+    api_keys: str = ""
+    allowed_origins: str = "*"
+    rate_limit_per_min: int = 120
+    cache_ttl: int = 60
+
+settings = Settings()
+
+OLLAMA_URL = settings.ollama_url
+API_KEYS = {k.strip() for k in settings.api_keys.split(",") if k.strip()}
+ALLOWED_ORIGINS = [o.strip() for o in settings.allowed_origins.split(",") if o.strip()]
+RATE_LIMIT_PER_MIN = settings.rate_limit_per_min
+MODELS_TTL = settings.cache_ttl
 
 APP_NAME = "jarvik-model-gateway"
 APP_VERSION = "1.0.0-lan"
 
 # ===== App & CORS =====
-app = FastAPI(title=APP_NAME, version=APP_VERSION)
+async def lifespan(app: FastAPI):
+    timeout = httpx.Timeout(300.0, connect=10.0)
+    async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
+        app.state.client = client
+        yield
+
+app = FastAPI(title=APP_NAME, version=APP_VERSION, lifespan=lifespan)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=ALLOWED_ORIGINS if ALLOWED_ORIGINS else ["*"],
@@ -54,8 +72,13 @@ def _auth_check(auth_header: Optional[str]) -> str:
         raise HTTPException(status_code=403, detail="Invalid API key")
     return token
 
-# ===== HTTP klient na Ollamu =====
-client = httpx.AsyncClient(timeout=httpx.Timeout(300.0, connect=10.0), follow_redirects=True)
+async def verify_request(
+    request: Request,
+    authorization: str = Header(None)
+) -> str:
+    api_key = _auth_check(authorization)
+    _check_rl(api_key, request.client.host if request and request.client else "")
+    return api_key
 
 # ===== Mapování OpenAI↔Ollama =====
 def _map_openai_to_ollama_chat(payload: Dict[str, Any]) -> Dict[str, Any]:
@@ -95,9 +118,76 @@ def _openai_final(model: str, text: str) -> Dict[str, Any]:
         "usage": {"prompt_tokens": None, "completion_tokens": None, "total_tokens": None}
     }
 
+# ===== Pydantic modely =====
+class Message(BaseModel):
+    role: Literal["system", "user", "assistant"]
+    content: str
+
+class ChatRequest(BaseModel):
+    model: str
+    messages: List[Message]
+    stream: bool = False
+    temperature: Optional[float] = 0.7
+    top_p: Optional[float] = 1.0
+    max_tokens: Optional[int] = None
+    stop: Optional[Union[List[str], str]] = None
+
+class Choice(BaseModel):
+    index: int
+    message: Message
+    finish_reason: Optional[str] = None
+
+class ChatResponse(BaseModel):
+    id: str
+    object: Literal["chat.completion"] = "chat.completion"
+    model: str
+    choices: List[Choice]
+    usage: Optional[Dict[str, Any]] = None
+
+class EmbeddingRequest(BaseModel):
+    model: str
+    input: Union[str, List[str]]
+
+class EmbeddingData(BaseModel):
+    object: Literal["embedding"] = "embedding"
+    embedding: List[float]
+    index: int
+
+class EmbeddingResponse(BaseModel):
+    object: Literal["list"] = "list"
+    data: List[EmbeddingData]
+    model: str
+    usage: Dict[str, Any]
+
+class ModelItem(BaseModel):
+    id: str
+    object: Literal["model"] = "model"
+
+class ModelListResponse(BaseModel):
+    object: Literal["list"] = "list"
+    data: List[ModelItem]
+
+# ===== Cache modelů =====
+_models_cache: Dict[str, Tuple[float, Any]] = {}
+MODELS_CACHE_KEY = "ollama/models"
+
+async def get_models_cached(request: Request):
+    now = time.time()
+    cached = _models_cache.get(MODELS_CACHE_KEY)
+    if cached and now - cached[0] < MODELS_TTL:
+        return cached[1]
+    client: httpx.AsyncClient = request.app.state.client
+    r = await client.get(f"{OLLAMA_URL}/api/tags")
+    if r.status_code != 200:
+        raise HTTPException(status_code=502, detail="Ollama not available")
+    data = r.json().get("models", [])
+    _models_cache[MODELS_CACHE_KEY] = (now, data)
+    return data
+
 # ===== Health & modely =====
 @app.get("/healthz")
-async def healthz():
+async def healthz(request: Request):
+    client: httpx.AsyncClient = request.app.state.client
     try:
         r = await client.get(f"{OLLAMA_URL}/api/tags")
         ok = r.status_code == 200
@@ -105,31 +195,27 @@ async def healthz():
         ok = False
     return {"name": APP_NAME, "version": APP_VERSION, "ollama_ok": ok}
 
-@app.get("/v1/models")
-async def list_models(authorization: Optional[str] = Header(None), request: Request = None):
-    api_key = _auth_check(authorization)
-    _check_rl(api_key, request.client.host if request and request.client else "")
-    r = await client.get(f"{OLLAMA_URL}/api/tags")
-    if r.status_code != 200:
-        raise HTTPException(status_code=502, detail="Ollama not available")
-    data = r.json().get("models", [])
-    return {"object": "list", "data": [{"id": m.get("name",""), "object": "model"} for m in data]}
+@app.get("/v1/models", response_model=ModelListResponse)
+async def list_models(request: Request, api_key: str = Depends(verify_request)):
+    data = await get_models_cached(request)
+    return ModelListResponse(
+        object="list",
+        data=[ModelItem(id=m.get("name", "")) for m in data]
+    )
 
 # ===== Chat completions =====
-@app.post("/v1/chat/completions")
-async def chat_completions(request: Request, authorization: Optional[str] = Header(None)):
-    api_key = _auth_check(authorization)
-    _check_rl(api_key, request.client.host if request and request.client else "")
-    payload = await request.json()
-    model = payload.get("model", "unknown")
-    ollama_payload = _map_openai_to_ollama_chat(payload)
+@app.post("/v1/chat/completions", response_model=ChatResponse)
+async def chat_completions(req: ChatRequest, request: Request, api_key: str = Depends(verify_request)):
+    client: httpx.AsyncClient = request.app.state.client
+    model = req.model
+    ollama_payload = _map_openai_to_ollama_chat(req.dict())
 
-    if not payload.get("stream", False):
+    if not req.stream:
         r = await client.post(f"{OLLAMA_URL}/api/chat", json=ollama_payload)
         if r.status_code != 200:
             raise HTTPException(status_code=502, detail=f"Ollama error: {r.text}")
         text = r.json().get("message", {}).get("content", "")
-        return JSONResponse(_openai_final(model, text))
+        return ChatResponse(**_openai_final(model, text))
 
     async def event_gen():
         async with client.stream("POST", f"{OLLAMA_URL}/api/chat", json=ollama_payload) as resp:
@@ -157,30 +243,28 @@ async def chat_completions(request: Request, authorization: Optional[str] = Head
     return StreamingResponse(event_gen(), media_type="text/event-stream")
 
 # ===== Embeddings =====
-@app.post("/v1/embeddings")
-async def embeddings(request: Request, authorization: Optional[str] = Header(None)):
-    api_key = _auth_check(authorization)
-    _check_rl(api_key, request.client.host if request and request.client else "")
-    payload = await request.json()
-    model = payload.get("model", "")
-    _input = payload.get("input")
-    if _input is None:
-        raise HTTPException(status_code=400, detail="Missing 'input'")
-    texts: List[str] = [str(t) for t in (_input if isinstance(_input, list) else [_input])]
+@app.post("/v1/embeddings", response_model=EmbeddingResponse)
+async def embeddings(req: EmbeddingRequest, request: Request, api_key: str = Depends(verify_request)):
+    client: httpx.AsyncClient = request.app.state.client
+    texts: List[str] = [str(t) for t in (req.input if isinstance(req.input, list) else [req.input])]
     results = []
     for t in texts:
-        r = await client.post(f"{OLLAMA_URL}/api/embeddings", json={"model": model, "prompt": t})
+        r = await client.post(f"{OLLAMA_URL}/api/embeddings", json={"model": req.model, "prompt": t})
         if r.status_code != 200:
             raise HTTPException(status_code=502, detail=f"Ollama embeddings error: {r.text}")
         emb = r.json().get("embedding", [])
-        results.append({"object": "embedding", "embedding": emb, "index": len(results)})
-    return {"object": "list", "data": results, "model": model, "usage": {"prompt_tokens": None, "total_tokens": None}}
+        results.append(EmbeddingData(embedding=emb, index=len(results)))
+    return EmbeddingResponse(
+        object="list",
+        data=results,
+        model=req.model,
+        usage={"prompt_tokens": None, "total_tokens": None}
+    )
 
 @app.get("/")
 async def root():
     return {"service": APP_NAME, "version": APP_VERSION, "mode": "LAN", "endpoints": ["/healthz", "/v1/models", "/v1/chat/completions", "/v1/embeddings"]}
 
 if __name__ == "__main__":
-    # *** LAN režim: naslouchá na všech rozhraních ***
     import uvicorn
     uvicorn.run("app:app", host="0.0.0.0", port=8095, reload=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi==0.112.2
 uvicorn[standard]==0.30.6
 httpx==0.27.2
+pydantic-settings==2.3.4


### PR DESCRIPTION
## Summary
- manage async HTTP client via FastAPI lifespan
- centralize auth + rate limiting dependency
- add Pydantic request/response models and model cache
- configure service using pydantic-settings

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pydantic-settings==2.3.4)*

------
https://chatgpt.com/codex/tasks/task_b_68b757e4170083228064b276917c614a