### PR TITLE
docs: add docker usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,51 @@ The service listens on port `8095` by default.
 - `POST /v1/embeddings` – generate embeddings
 
 All endpoints require a Bearer token defined in the `API_KEYS` environment variable.
+
+## Running Local Models via Docker
+
+1. Verify locally available images:
+
+```bash
+docker images
+```
+
+Expected list:
+- at-code:latest
+- chat-qwen:latest
+- smollm:1.7b
+- codegemma:2b
+- qwen3:1.7b
+- codegemma2b-tuned:latest
+- stable-code:3b
+
+2. Start a container for a model:
+
+```bash
+docker run -it --rm --gpus all -p HOST_PORT:8000 IMAGE_NAME
+```
+
+### Example commands
+
+```bash
+docker run -it --rm --gpus all -p 8000:8000 at-code:latest
+docker run -it --rm --gpus all -p 8001:8000 chat-qwen:latest
+docker run -it --rm --gpus all -p 8002:8000 smollm:1.7b
+docker run -it --rm --gpus all -p 8003:8000 codegemma:2b
+docker run -it --rm --gpus all -p 8004:8000 qwen3:1.7b
+docker run -it --rm --gpus all -p 8005:8000 codegemma2b-tuned:latest
+docker run -it --rm --gpus all -p 8006:8000 stable-code:3b
+```
+
+3. Test a running model:
+
+```bash
+curl http://localhost:HOST_PORT
+```
+
+### Additional tips
+- `--gpus all` requires Docker with GPU support.
+- Adjust host ports (`-p HOST_PORT:8000`) to avoid conflicts.
+- Use `docker logs <container_id>` for debugging.
+- Restrict public access with firewall rules or authentication when exposing ports.
+


### PR DESCRIPTION
## Summary
- document how to run local models with Docker

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b764580dc483229706a3f15fb74b59