### PR TITLE
Expose model details in API

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The service listens on port `8095` by default.
 ## Endpoints
 
 - `GET /healthz` – basic health check
-- `GET /v1/models` – list available models
+- `GET /v1/models` – list available models including `name`, `id`, `size` and `modified`
 - `POST /v1/chat/completions` – create chat completions (supports streaming)
 - `POST /v1/embeddings` – generate embeddings
 


### PR DESCRIPTION
## Summary
- add helper functions to return human-readable model size and modification times
- extend `/v1/models` endpoint to return name, id, size and modified for each model
- document the expanded model listing

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ba22ee2f0483228ae7a45849cfba47